### PR TITLE
Add Keys module for Orange Pi keyboard

### DIFF
--- a/firmware/orangepi/keys/__init__.py
+++ b/firmware/orangepi/keys/__init__.py
@@ -1,0 +1,7 @@
+"""Touchscreen keyboard module."""
+
+from .state import KeyboardState
+from .renderer import render_keyboard
+from .input_handler import process_touch
+
+__all__ = ["KeyboardState", "render_keyboard", "process_touch"]

--- a/firmware/orangepi/keys/input_handler.py
+++ b/firmware/orangepi/keys/input_handler.py
@@ -1,0 +1,42 @@
+"""Touch input processing for the on-screen keyboard."""
+
+from typing import Optional
+
+from . import layout
+from .state import KeyboardState
+
+
+def process_touch(x: int, y: int, state: KeyboardState, width: int = layout.SCREEN_WIDTH, height: int = layout.SCREEN_HEIGHT) -> Optional[str]:
+    """Process a touch at the given coordinates.
+
+    Returns the character inserted into the buffer or ``None`` if no key
+    was pressed.
+    """
+    keys = layout.build_layout(state.layout, width, height)
+    for key in keys:
+        if key.contains(x, y):
+            return _handle_key_press(key.value, state)
+    return None
+
+
+def _handle_key_press(value: str, state: KeyboardState) -> Optional[str]:
+    if value == "shift":
+        # Toggle between abc and ABC layouts
+        state.layout = "ABC" if state.layout == "abc" else "abc"
+        return None
+    elif value in ("abc", "ABC", "123"):
+        state.layout = value
+        return None
+    elif value == "space":
+        state.insert(" ")
+        return " "
+    elif value == "enter":
+        state.insert("\n")
+        state.entered = True
+        return "\n"
+    elif value == "backspace":
+        state.backspace()
+        return None
+    else:
+        state.insert(value)
+        return value

--- a/firmware/orangepi/keys/layout.py
+++ b/firmware/orangepi/keys/layout.py
@@ -1,0 +1,69 @@
+"""Keyboard layout definitions for the Keys module.
+
+This module describes several simple keyboard layouts used by the
+on-screen keyboard. Layouts are defined as lists of rows, where each
+row is a list of key labels. All keys in a single row occupy equal
+width when rendered.
+"""
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+# Default screen dimensions for the Waveshare 2.9" touch e-paper.
+SCREEN_WIDTH = 296
+SCREEN_HEIGHT = 128
+
+@dataclass
+class Key:
+    label: str
+    value: str
+    bounds: Tuple[int, int, int, int]  # (x0, y0, x1, y1)
+
+    def contains(self, x: int, y: int) -> bool:
+        x0, y0, x1, y1 = self.bounds
+        return x0 <= x < x1 and y0 <= y < y1
+
+
+# Raw layouts expressed as rows of labels. Special keys use
+# lowercase names so they can be distinguished from printable
+# characters.
+RAW_LAYOUTS = {
+    "abc": [
+        list("qwertyuiop"),
+        list("asdfghjkl"),
+        ["shift", "z", "x", "c", "v", "b", "n", "m", "backspace"],
+        ["123", "space", "enter"],
+    ],
+    "ABC": [
+        list("QWERTYUIOP"),
+        list("ASDFGHJKL"),
+        ["shift", "Z", "X", "C", "V", "B", "N", "M", "backspace"],
+        ["123", "space", "enter"],
+    ],
+    "123": [
+        list("1234567890"),
+        ["-", "/", ":", ";", "(", ")", "@", "&", "?"],
+        ["abc", ".", ",", "'", "\"", "!", "#", "backspace"],
+        ["ABC", "space", "enter"],
+    ],
+}
+
+
+def build_layout(name: str, width: int = SCREEN_WIDTH, height: int = SCREEN_HEIGHT) -> List[Key]:
+    """Return a list of :class:`Key` objects for the given layout name."""
+    rows = RAW_LAYOUTS.get(name)
+    if not rows:
+        raise ValueError(f"Unknown layout: {name}")
+
+    row_height = height // len(rows)
+    keys: List[Key] = []
+
+    for r, row in enumerate(rows):
+        col_width = width // len(row)
+        for c, label in enumerate(row):
+            x0 = c * col_width
+            y0 = r * row_height
+            x1 = x0 + col_width
+            y1 = y0 + row_height
+            keys.append(Key(label=label, value=label, bounds=(x0, y0, x1, y1)))
+    return keys

--- a/firmware/orangepi/keys/renderer.py
+++ b/firmware/orangepi/keys/renderer.py
@@ -1,0 +1,30 @@
+"""Simple keyboard renderer using Pillow."""
+
+from PIL import Image, ImageDraw, ImageFont
+from . import layout
+from .state import KeyboardState
+
+# Try to load a default font. Pillow will fall back to a simple bitmap
+# font if truetype fonts are not available.
+try:
+    DEFAULT_FONT = ImageFont.truetype("DejaVuSans.ttf", 14)
+except Exception:  # pragma: no cover - font availability may vary
+    DEFAULT_FONT = ImageFont.load_default()
+
+
+def render_keyboard(state: KeyboardState, width: int = layout.SCREEN_WIDTH, height: int = layout.SCREEN_HEIGHT) -> Image.Image:
+    """Render the keyboard to a Pillow :class:`Image`."""
+    img = Image.new("1", (width, height), 1)  # 1-bit image, white background
+    draw = ImageDraw.Draw(img)
+
+    keys = layout.build_layout(state.layout, width, height)
+    for key in keys:
+        x0, y0, x1, y1 = key.bounds
+        draw.rectangle(key.bounds, outline=0, fill=1)
+        text = key.label
+        tw, th = draw.textsize(text, font=DEFAULT_FONT)
+        tx = x0 + (x1 - x0 - tw) // 2
+        ty = y0 + (y1 - y0 - th) // 2
+        draw.text((tx, ty), text, font=DEFAULT_FONT, fill=0)
+
+    return img

--- a/firmware/orangepi/keys/state.py
+++ b/firmware/orangepi/keys/state.py
@@ -1,0 +1,34 @@
+"""Keyboard state handling."""
+from dataclasses import dataclass, field
+
+
+def clamp(value: int, minimum: int, maximum: int) -> int:
+    return max(minimum, min(value, maximum))
+
+
+@dataclass
+class KeyboardState:
+    """Represents current keyboard state and input buffer."""
+
+    layout: str = "abc"
+    buffer: str = ""
+    cursor: int = 0
+
+    entered: bool = False
+
+    def insert(self, char: str) -> None:
+        self.buffer = self.buffer[: self.cursor] + char + self.buffer[self.cursor :]
+        self.cursor += len(char)
+
+    def backspace(self) -> None:
+        if self.cursor > 0:
+            self.buffer = self.buffer[: self.cursor - 1] + self.buffer[self.cursor :]
+            self.cursor -= 1
+
+    def move_cursor(self, offset: int) -> None:
+        self.cursor = clamp(self.cursor + offset, 0, len(self.buffer))
+
+    def clear(self) -> None:
+        self.buffer = ""
+        self.cursor = 0
+        self.entered = False


### PR DESCRIPTION
## Summary
- create keyboard module in `firmware/orangepi/keys`
- implement simple layouts, state management, renderer and input handler

## Testing
- `python -m py_compile firmware/orangepi/keys/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68432a50c0a08325a0b43ece6d9a41fb